### PR TITLE
min & max lifespan of a message

### DIFF
--- a/src/Fcm.php
+++ b/src/Fcm.php
@@ -41,11 +41,18 @@ class Fcm
 
         return $this;
     }
-    
+
     public function timeToLive(int $timeToLive)
     {
+        if ($timeToLive < 0) {
+            $timeToLive = 0; // (0 seconds)
+        }
+        if ($timeToLive > 2419200) {
+            $timeToLive = 2419200; // (28 days)
+        }
+
         $this->timeToLive = $timeToLive;
-        
+
         return $this;
     }
 
@@ -65,7 +72,7 @@ class Fcm
         } else {
             $payloads['registration_ids'] = $this->recipients;
         }
-        
+
         if ($this->timeToLive !== null && $this->timeToLive >= 0) {
             $payloads['time_to_live'] = (int) $this->timeToLive;
         }


### PR DESCRIPTION
https://firebase.google.com/docs/cloud-messaging/concept-options#ttl
`The value must be a duration from 0 to 2,419,200 seconds (28 days), and it corresponds to the maximum period of time for which FCM stores and attempts to deliver the message`