### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php" : "^5.6|^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0"
+        "illuminate/support": "^5.1|^6.0"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
As the title suggested, adding support for Laravel 6.0. I also clean the version constraint for `illuminate/support`, as it yields same result with less character ([tilde operator](https://semver.mwl.be/#!?package=illuminate%2Fsupport&version=~5.1.0%7C~5.2.0%7C~5.3.0%7C~5.4.0%7C~5.5.0%7C~5.6.0%7C~5.7.0%7C~5.8.0%7C~6.0.0&minimum-stability=stable) vs. [caret operator](https://semver.mwl.be/#!?package=illuminate%2Fsupport&version=%5E5.1%7C%5E6.0&minimum-stability=stable)).

It's also recommended by Composer's [versions and constraints guide](https://getcomposer.org/doc/articles/versions.md#caret-version-range-), "for maximum interoperability when writing library code."