### PR TITLE
Note added in readme about sending different payloads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,3 +122,30 @@ fcm()
     ])
     ->send();
 ```
+
+### Notes
+
+## Sending different payloads
+
+This packages uses a singleton pattern for the `Fcm` facade and `fcm()` helper.
+If you want to send diffent payloads to Firebase in the same request you have to use use the `Kawankoding\Fcm\Fcm` class directly:
+
+```php
+use Kawankoding\Fcm\Fcm;
+
+$fcm1 = new Fcm;
+$fcm1->to($recipients)
+    ->data([
+        'title' => 'Test FCM 1',
+        'body' => 'This is a test of FCM 1',
+    ])
+    ->send();
+
+$fcm2 = new Fcm;
+$fcm2->to($recipients)
+    ->notification([
+        'title' => 'Test FCM 2',
+        'body' => 'This is a test of FCM 2',
+    ])
+    ->send();
+```

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ fcm()
 ## Sending different payloads
 
 This packages uses a singleton pattern for the `Fcm` facade and `fcm()` helper.
-If you want to send diffent payloads to Firebase in the same request you have to use use the `Kawankoding\Fcm\Fcm` class directly:
+If you want to send different payloads to Firebase in the same request you have to use use the `Kawankoding\Fcm\Fcm` class directly:
 
 ```php
 use Kawankoding\Fcm\Fcm;


### PR DESCRIPTION
I am using this package to send different payloads to Android devices and iOS devices in one request. This gave me some problems, because this package reuses the`Fcm` class via a singleton.

**iOS:**
```
fcm()->to($recipients)
  ->notification([
    'title' => 'title',
  ])
  ->data([
    'title' => 'title',
  ])
  ->send()
```

**Android:**
```
fcm()->to($recipients)
  ->data([
    'title' => 'title',
  ])
  ->send();
```

If i send an iOS notification first the `Fcm` class has a `$notification` property which gives problems inside the Android app. However I am not able to reset  / remove this property from the `Fcm` class anymore.

**Failed solutions:**
An empty array in the notification method gives a `null` response from Firebase:
```
fcm()->to($recipients)
  ->notification([])
  ->data([
    'title' => 'title',
  ])
  ->send();
```

A `null` in notification method is not possible because of typehinting in the current package
```
fcm()->to($recipients)
  ->notification(null)
  ->data([
    'title' => 'title',
  ])
  ->send();
```

**Note in docs:**
That is why I added  a note to the docs with a workaround by using the `Fcm` class directly instead the the facade or helper.

Would be nice to in the future to be able to reset class properties in the `Fcm` class by updating them with `null`. I could make PR for that too if you are interested.
